### PR TITLE
[Feat] Baseline support (1/2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,9 @@
+name = "RootIO"
+uuid = "84287b9e-b673-4340-bb1d-a334fb11fbd4"
+authors = ["Yash Solanki <67216443+yashnator@users.noreply.github.com>"]
+version = "0.1.0"
+
+[deps]
+CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+ROOT = "1706fdcc-8426-44f1-a283-5be479e9517c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/src/RootIO.jl
+++ b/src/RootIO.jl
@@ -1,0 +1,73 @@
+module RootIO
+
+import ROOT, Tables, CxxWrap
+
+struct TTree
+    _ROOT_ttree::ROOT.TTree
+    _branch_array
+    _file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}
+end
+
+function Write(tree::TTree)
+    ROOT.Write(tree._ROOT_ttree)
+end
+
+function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
+
+    println("Creating a new TTree")
+
+    _tree = ROOT.TTree(name, title)
+
+    _branch_types_array = []
+    _branch_names_array = []
+    if isa(data, DataType)
+        _branch_types_array = fieldtypes(data)
+        _branch_names_array = fieldnames(data)
+    else
+        _branch_types_array = fieldtypes(typeof(data))
+        _branch_names_array = fieldnames(typeof(data))
+    end
+    _curr_branch_array = []
+
+    for i in 1:fieldcount(data)
+        if _branch_types_array[i] <: CxxWrap.StdVector
+            _ptr = (_branch_types_array[i])()
+            _curr_branch = ROOT.Branch(_tree, string(_branch_names_array[i]), _ptr, 100, 99)
+            push!(_curr_branch_array, _curr_branch)
+        else
+            _curr_branch = ROOT.Branch(_tree, string(_branch_names_array[i]), Ref(one(_branch_types_array[i])), 100, 99)
+            push!(_curr_branch_array, _curr_branch)
+        end
+    end
+
+    it = TTree(_tree, _curr_branch_array, file)
+
+    if !isa(data, DataType)
+        Fill(it, data)
+    end
+
+    return it
+end
+
+function Fill(tree::TTree, data)
+    if Tables.istable(data)
+        println("Filling the TTree with a table")
+        for row in Tables.rows(data)
+            Fill(tree, row)
+        end
+    else
+        println("Filling the TTtree with a row")
+        row = map(field -> getfield(data, field), fieldnames(typeof(data)))
+        for i in 1:length(tree._branch_array)
+            if typeof(row[i]) <: CxxWrap.StdVector
+                ROOT.SetObject(tree._branch_array[i], row[i])
+            else
+                ROOT.SetAddress(tree._branch_array[i], Ref(row[i]))
+            end
+        end
+        _preserved_vars = tree._branch_array
+        GC.@preserve _preserved_vars ROOT.Fill(tree._ROOT_ttree)
+    end
+end 
+
+end # module RootIO


### PR DESCRIPTION
## Description

This pull request is part (1/2) of the baseline support for RootIO. The PR provides functions to create a new TTree, allowing row-by-row and multi-row writing to the TFile.

The following struct stores the necessary data for I/O operations:

- `TTree(_ROOT_ttree, _branch_array, _file)`: for holding TTree, branches of TTree & output file

The following functions are added to the module:
- `Write(tree)`: Writes the TTree to the currently opened TFile
- `TTree(file, name, title, data)`: Creates a new TTree in the TFile `file` with the name `name`, title `title` & data `data` (that can be array of types too)
- `Fill(tree, data)`: Fills the tree with row data or a table

## Example use case:

```julia
import RootIO, ROOT
using CxxWrap

mutable struct Event
    x::Float32
    y::Float32
    z::Float32
    v::StdVector{Float32}
end

f = ROOT.TFile!Open("data.root", "RECREATE")

Event()  = Event(0., 0., 0., StdVector{Float32}())

tree = RootIO.TTree(f, "mytree", "mytreetitle", Event)

e = Event()
for i in 1:10
    e.x, e.y, e.z = rand(3)
    resize!.([e.v], 5)
    e.v .= rand(Float32, 5)
    RootIO.Fill(tree, e)
end

RootIO.Write(tree)
ROOT.Close(f)

```

## Checklist before requesting a review
- [x] Tested locally
