### PR TITLE
[Feat] Baseline support (2/2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RootIO"
 uuid = "84287b9e-b673-4340-bb1d-a334fb11fbd4"
-authors = ["Yash Solanki <67216443+yashnator@users.noreply.github.com>"]
+authors = ["Yash Solanki <252yash@gmail.com>"]
 version = "0.1.0"
 
 [deps]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+RootIO = "84287b9e-b673-4340-bb1d-a334fb11fbd4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,5 @@
+using Documenter, RootIO
+
+makedocs(
+    sitename="RootIO.jl Documentation"
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,5 @@
+# RootIO.jl Documentation
+
+```@autodocs
+Modules = [RootIO]
+```

--- a/src/RootIO.jl
+++ b/src/RootIO.jl
@@ -12,11 +12,25 @@ function Write(tree::TTree)
     ROOT.Write(tree._ROOT_ttree)
 end
 
+function _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, _branch_types, _branch_names)
+    _tree = ROOT.TTree(name, title)
+    _curr_branch_array = []
+    for i in 1:length(_branch_types)
+        if _branch_types[i] <: CxxWrap.StdVector
+            _ptr = (_branch_types[i])()
+            _curr_branch = ROOT.Branch(_tree, string(_branch_names[i]), _ptr, 100, 99)
+            push!(_curr_branch_array, _curr_branch)
+        else
+            _curr_branch = ROOT.Branch(_tree, string(_branch_names[i]), Ref(one(_branch_types[i])), 100, 99)
+            push!(_curr_branch_array, _curr_branch)
+        end
+    end
+    return TTree(_tree, _curr_branch_array, file)
+end
+
 function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
 
     println("Creating a new TTree")
-
-    _tree = ROOT.TTree(name, title)
 
     _branch_types_array = []
     _branch_names_array = []
@@ -27,23 +41,44 @@ function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title
         _branch_types_array = fieldtypes(typeof(data))
         _branch_names_array = fieldnames(typeof(data))
     end
-    _curr_branch_array = []
 
-    for i in 1:fieldcount(data)
-        if _branch_types_array[i] <: CxxWrap.StdVector
-            _ptr = (_branch_types_array[i])()
-            _curr_branch = ROOT.Branch(_tree, string(_branch_names_array[i]), _ptr, 100, 99)
-            push!(_curr_branch_array, _curr_branch)
-        else
-            _curr_branch = ROOT.Branch(_tree, string(_branch_names_array[i]), Ref(one(_branch_types_array[i])), 100, 99)
-            push!(_curr_branch_array, _curr_branch)
-        end
-    end
-
-    it = TTree(_tree, _curr_branch_array, file)
+    it = _makeTTree(file, name, title, _branch_types_array, _branch_names_array)
 
     if !isa(data, DataType)
         Fill(it, data)
+    end
+
+    return it
+end
+
+function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String; kwargs...)
+    println("Creating a new TTree")
+
+    _branch_types_array = []
+    _branch_names_array = NTuple{length(kwargs), Symbol}(collect(keys(kwargs)))
+
+    if isa(kwargs[1], DataType)
+        _branch_types_array = NTuple{length(kwargs), DataType}(collect(values(kwargs)))
+    else
+        _branch_types_array = NTuple{length(kwargs), DataType}([eltype(value) for value in values(kwargs)])
+    end
+
+    it = _makeTTree(file, name, title, _branch_types_array, _branch_names_array)
+
+    if !isa(kwargs[1], DataType)
+        num_rows = length(kwargs[1])
+        for curr_row in 1:num_rows
+            for curr_branch in 1:length(kwargs)
+                if typeof(kwargs[curr_branch][curr_row]) <: CxxWrap.StdVector
+                    ROOT.SetObject(it._branch_array[curr_branch], kwargs[curr_branch][curr_row])
+                else
+                    x = kwargs[curr_branch][curr_row]
+                    ROOT.SetAddress(it._branch_array[curr_branch], Ref(x))
+                end
+            end
+            _preserved_vars = it._branch_array
+            GC.@preserve _preserved_vars ROOT.Fill(it._ROOT_ttree)
+        end
     end
 
     return it

--- a/src/RootIO.jl
+++ b/src/RootIO.jl
@@ -2,16 +2,50 @@ module RootIO
 
 import ROOT, Tables, CxxWrap
 
+"""
+    struct TTree
+
+A struct representing a ROOT TTree with its associated branches and file.
+
+# Fields
+- `_ROOT_ttree`: The ROOT TTree object.
+- `_branch_array`: An array of branches associated with the TTree.
+- `_file`: A pointer to the ROOT file where the TTree is stored.
+"""
 struct TTree
     _ROOT_ttree::ROOT.TTree
     _branch_array
     _file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}
 end
 
+"""
+    Write(tree::TTree)
+
+Writes a ROOT TTree to the associated ROOT file.
+
+# Arguments
+- `tree::TTree`: The TTree object to be written to the ROOT file.
+"""
 function Write(tree::TTree)
     ROOT.Write(tree._ROOT_ttree)
 end
 
+
+"""
+    _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, _branch_types, _branch_names)
+
+Creates a ROOT TTree with specified branches.
+
+# Arguments
+- `file`: A pointer to a ROOT file where the TTree will be stored.
+- `name`: The name of the TTree.
+- `title`: The title of the TTree.
+- `_branch_types`: A collection of types for the branches.
+- `_branch_names`: A collection of names for the branches.
+
+# Returns
+- A RootIO `TTree` object containing the ROOT TTree and its branches.
+"""
 function _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, _branch_types, _branch_names)
     _tree = ROOT.TTree(name, title)
     _curr_branch_array = []
@@ -28,8 +62,38 @@ function _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, 
     return TTree(_tree, _curr_branch_array, file)
 end
 
-function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
+"""
+    TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
 
+Creates a new ROOT TTree and fills it with the provided data.
+
+# Arguments
+- `file`: A pointer to a ROOT file where the TTree will be stored.
+- `name`: The name of the TTree.
+- `title`: The title of the TTree.
+- `data`: The data used to define and optionally fill the branches of the TTree. This can be a `DataType` or an instance of a type with fields.
+
+# Example
+```julia
+mutable struct Event
+    x::Float32
+    y::Float32
+    z::Float32
+    v::StdVector{Float32}
+end
+f = ROOT.TFile!Open("data.root", "RECREATE")
+Event()  = Event(0., 0., 0., StdVector{Float32}())
+tree = RootIO.TTree(f, "mytree", "mytreetitle", Event)
+e = Event()
+for i in 1:10
+    e.x, e.y, e.z = rand(3)
+    resize!.([e.v], 5)
+    e.v .= rand(Float32, 5)
+    RootIO.Fill(tree, e)
+end
+````
+"""
+function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
     println("Creating a new TTree")
 
     _branch_types_array = []
@@ -51,12 +115,30 @@ function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title
     return it
 end
 
+"""
+    TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String; kwargs...)
+
+Creates a new ROOT TTree and fills it with the provided data.
+
+# Arguments
+- `file`: A pointer to a ROOT file where the TTree will be stored.
+- `name`: The name of the TTree.
+- `title`: The title of the TTree.
+- `kwargs...`: Named arguments representing the branches of the TTree. Each named argument is either a data type or an array of data.
+
+# Example
+```julia
+file = ROOT.TFile!Open("example.root", "RECREATE")
+name = "example_tree"
+title = "Example TTree"
+data = (col_float=rand(Float64, 3), col_int=rand(Int32, 3))
+tree = RootIO.TTree(file, name, title; data...)
+"""
 function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String; kwargs...)
     println("Creating a new TTree")
 
     _branch_types_array = []
     _branch_names_array = NTuple{length(kwargs), Symbol}(collect(keys(kwargs)))
-
     if isa(kwargs[1], DataType)
         _branch_types_array = NTuple{length(kwargs), DataType}(collect(values(kwargs)))
     else
@@ -84,6 +166,20 @@ function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title
     return it
 end
 
+"""
+    Fill(tree::TTree, data)
+
+Fills a ROOT TTree with the provided data.
+
+# Arguments
+- `tree`: The TTree object to be filled.
+- `data`: The data to fill the TTree with. This can be a table or a row.
+
+# Example
+```julia
+# Assuming `tree` is an existing TTree and `data` is a table or row
+Fill(tree, data)
+"""
 function Fill(tree::TTree, data)
     if Tables.istable(data)
         println("Filling the TTree with a table")

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ROOT = "1706fdcc-8426-44f1-a283-5be479e9517c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,10 @@ function _create_test_tree(data)
     name = "test_tree"
     title = "Test TTree"
     tree = RootIO.TTree(file, name, title; data...)
+    mat = hcat([col[2] for col in data]...)
+    for i in axes(mat, 1)
+        RootIO.Fill(tree, mat[i, :])
+    end
 
     RootIO.Write(tree)
     ROOT.Close(file)
@@ -22,10 +26,13 @@ function _test_tree(ele_type, num_events, data)
 
     @test nevts == num_events
     ROOT.GetEntry(t, 0)
-    @test typeof(a[]) == ele_type
+    @test isa((a[]), ele_type)
+    mat = hcat([col[2] for col in data]...)
     for i in 1:nevts
         ROOT.GetEntry(t, i - 1)
-        @test data[:col][i] == a[]
+        for j in axes(mat, 2)
+            @test mat[i][j] == a[j]
+        end
     end
 
     ROOT.Close(file)
@@ -34,49 +41,49 @@ end
 
 @testset "Writing Integers" begin
     @testset "Int8" begin
-        data = Dict(:col => rand(Int8, 2))
+        data = [:col => rand(Int8, 2)]
         _create_test_tree(data)
         _test_tree(Int8, 2, data)
     end
 
     @testset "UInt8" begin
-        data = Dict(:col => rand(UInt8, 2))
+        data = [:col => rand(UInt8, 2)]
         _create_test_tree(data)
         _test_tree(UInt8, 2, data)
     end
 
     @testset "Int16" begin
-        data = Dict(:col => rand(Int16, 2))
+        data = [:col => rand(Int16, 2)]
         _create_test_tree(data)
         _test_tree(Int16, 2, data)
     end
 
     @testset "UInt16" begin
-        data = Dict(:col => rand(UInt16, 2))
+        data = [:col => rand(UInt16, 2)]
         _create_test_tree(data)
         _test_tree(UInt16, 2, data)
     end
 
     @testset "Int32" begin
-        data = Dict(:col => rand(Int32, 2))
+        data = [:col => rand(Int32, 2)]
         _create_test_tree(data)
         _test_tree(Int32, 2, data)
     end
 
     @testset "UInt32" begin
-        data = Dict(:col => rand(UInt32, 2))
+        data = [:col => rand(UInt32, 2)]
         _create_test_tree(data)
         _test_tree(UInt32, 2, data)
     end
 
     @testset "Int64" begin
-        data = Dict(:col => rand(Int64, 2))
+        data = [:col => rand(Int64, 2)]
         _create_test_tree(data)
         _test_tree(Int64, 2, data)
     end
 
     @testset "UInt64" begin
-        data = Dict(:col => rand(UInt64, 2))
+        data = [:col => rand(UInt64, 2)]
         _create_test_tree(data)
         _test_tree(UInt64, 2, data)
     end
@@ -84,13 +91,13 @@ end
 
 @testset "Writing Float" begin
     @testset "Float32" begin
-        data = Dict(:col => rand(Float32, 2))
+        data = [:col => rand(Float32, 2)]
         _create_test_tree(data)
         _test_tree(Float32, 2, data)
     end
 
     @testset "Float64" begin
-        data = Dict(:col => rand(Float64, 2))
+        data = [:col => rand(Float64, 2)]
         _create_test_tree(data)
         _test_tree(Float64, 2, data)
     end
@@ -99,7 +106,7 @@ end
 @testset "Writing Booleans" begin
     @testset "Bools" begin
         num_events = 3
-        data = Dict(:col => rand(Bool, num_events))
+        data = [:col => rand(Bool, num_events)]
         _create_test_tree(data)
 
         file = ROOT.TFile!Open("test.root")
@@ -111,10 +118,13 @@ end
 
         @test nevts == num_events
         ROOT.GetEntry(t, 0)
-        @test typeof(a[]) == Bool
+        @test isa(a[], Bool)
+        mat = hcat([col[2] for col in data]...)
         for i in 1:nevts
             ROOT.GetEntry(t, i - 1)
-            @test data[:col][i] == a[]
+            for j in axes(mat, 2)
+                @test mat[i][j] == a[j]
+            end
         end
 
         ROOT.Close(file)
@@ -137,7 +147,7 @@ end
 
         @test nevts == 3
         ROOT.GetEntry(t, 0)
-        @test typeof(unsafe_string(pointer(s))) == String
+        @test isa(unsafe_string(pointer(s)), String)
         for i in 1:nevts
             ROOT.GetEntry(t, i - 1)
             @test data[:col][i] == unsafe_string(pointer(s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,97 @@
+using Test
+import RootIO, ROOT
+
+function _create_test_tree(data)
+    file = ROOT.TFile!Open("test.root", "RECREATE")
+
+    name = "test_tree"
+    title = "Test TTree"
+    tree = RootIO.TTree(file, name, title; data...)
+
+    RootIO.Write(tree)
+    ROOT.Close(file)
+end
+
+function _test_tree(ele_type, num_events, data)
+    file = ROOT.TFile!Open("test.root")
+    t = ROOT.GetTTree(file[], "test_tree")
+
+    a = fill(ele_type(0))
+    ROOT.SetBranchAddress(t[], "col", a)
+    nevts = ROOT.GetEntries(t)
+
+    @test nevts == num_events
+    ROOT.GetEntry(t, 0)
+    @test typeof(a[]) == ele_type
+    for i in 1:nevts
+        ROOT.GetEntry(t, i - 1)
+        @test data[:col][i] == a[]
+    end
+
+    ROOT.Close(file)
+    rm("test.root")
+end
+
+@testset "Writing Integers" begin
+    @testset "Int8" begin
+        data = Dict(:col => rand(Int8, 2))
+        _create_test_tree(data)
+        _test_tree(Int8, 2, data)
+    end
+
+    @testset "UInt8" begin
+        data = Dict(:col => rand(UInt8, 2))
+        _create_test_tree(data)
+        _test_tree(UInt8, 2, data)
+    end
+
+    @testset "Int16" begin
+        data = Dict(:col => rand(Int16, 2))
+        _create_test_tree(data)
+        _test_tree(Int16, 2, data)
+    end
+
+    @testset "UInt16" begin
+        data = Dict(:col => rand(UInt16, 2))
+        _create_test_tree(data)
+        _test_tree(UInt16, 2, data)
+    end
+
+    @testset "Int32" begin
+        data = Dict(:col => rand(Int32, 2))
+        _create_test_tree(data)
+        _test_tree(Int32, 2, data)
+    end
+
+    @testset "UInt32" begin
+        data = Dict(:col => rand(UInt32, 2))
+        _create_test_tree(data)
+        _test_tree(UInt32, 2, data)
+    end
+
+    @testset "Int64" begin
+        data = Dict(:col => rand(Int64, 2))
+        _create_test_tree(data)
+        _test_tree(Int64, 2, data)
+    end
+
+    @testset "UInt64" begin
+        data = Dict(:col => rand(UInt64, 2))
+        _create_test_tree(data)
+        _test_tree(UInt64, 2, data)
+    end
+end
+
+@testset "Writing Float" begin
+    @testset "Float32" begin
+        data = Dict(:col => rand(Float32, 2))
+        _create_test_tree(data)
+        _test_tree(Float32, 2, data)
+    end
+
+    @testset "Float64" begin
+        data = Dict(:col => rand(Float64, 2))
+        _create_test_tree(data)
+        _test_tree(Float64, 2, data)
+    end
+end


### PR DESCRIPTION
This pull request is part (1/2) of the baseline support for RootIO. 

The PR provides functions to:
- Create a new TTree using keyword arguments
- Adds docstrings and documenter.jl
- Adds unit tests
- Adds support for writing boolean and strings(as char*)

Example:
```julia
import RootIO, ROOT
using DataFrames
file = ROOT.TFile!Open("example.root", "RECREATE")

name = "example_tree"
title = "Example TTree"
data = (col_float=rand(Float64, 3), col_int=rand(Int32, 3))
tree = RootIO.TTree(file, name, title; data...)

RootIO.Write(tree)
ROOT.Close(file)
```

Checklist before requesting a review:
- [x] Tested locally