### PR TITLE
[Docs] Documentation and CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Pull Request Template
+
+## Description
+
+Briefly describe the purpose of the changes made in this pull request.
+
+## Related Issue
+
+Link to the relevant issue, if any: Closes #<issue_number>
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Testing
+
+Describe the tests you ran to verify your changes. Include instructions for replication.
+
+## Checklist
+
+- [ ] Tested locally
+- [ ] Added unit tests
+- [ ] Updated documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,17 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+docs/.DS_Store

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,13 @@
+push!(LOAD_PATH,"../src/")
 using Documenter, RootIO
 
 makedocs(
-    sitename="RootIO.jl Documentation"
+    sitename = "RootIO.jl",
+    modules = [RootIO],
+    checkdocs = :exports
+)
+
+deploydocs(
+    repo = "github.com/JuliaHEP/RootIO.jl",
+    push_preview = true
 )

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,1 @@
+# Examples

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,1 +1,116 @@
 # Examples
+
+## Writing primitive types
+
+All the primitive types and structs can be written to the TTree using the RootIO.jl library. By convention, a data type or an instance of the column can be used to create the columns. 
+
+A complete list of supported Julia and ROOT custom types can be found in the [introduction page](@ref Introduction).
+
+!!! tip "Creating TTree with columns instances"
+    Creating a TTree with row instance only infers the types from the instance, and doesn't write it to the TTree
+
+### Writing to a TTree using keyword-argument and instance of row
+
+Keyword-arguments can be used to pass instance of a column to the tree. The types and names are inferred from the arguments.
+
+```julia
+import RootIO, ROOT
+using DataFrames
+file = ROOT.TFile!Open("example.root", "RECREATE")
+name = "example_tree"
+title = "Example TTree"
+data = (col_float=rand(Float64, 3), col_int=rand(Int32, 3))
+tree = RootIO.TTree(file, name, title; data...)
+RootIO.Write(tree)
+ROOT.Close(file)
+```
+
+### Writing a struct to a TTree
+
+The fieldnames and field types of the struct are used to create the branches of the TTree.
+
+```julia
+import RootIO, ROOT
+using CxxWrap
+mutable struct Event
+    x::Float32
+    y::Float32
+    z::Float32
+    v::StdVector{Float32}
+end
+f = ROOT.TFile!Open("data.root", "RECREATE")
+Event()  = Event(0., 0., 0., StdVector{Float32}())
+tree = RootIO.TTree(f, "mytree", "mytreetitle", Event)
+e = Event()
+for i in 1:10
+    e.x, e.y, e.z = rand(3)
+    resize!.([e.v], 5)
+    e.v .= rand(Float32, 5)
+    RootIO.Fill(tree, e)
+end
+RootIO.Write(tree)
+ROOT.Close(f)
+```
+
+## Writing vectors
+
+RootIO.jl supports writing of the ```CxxWrap.StdVector``` that wraps the ```std::vector``` from C/C++.
+
+```julia
+import RootIO, ROOT, CxxWrap
+# Create and open the ROOT file
+file = ROOT.TFile!Open("example.root", "RECREATE")
+name = "example_tree"
+title = "Example TTree"
+v = StdVector{Float32}()
+# Create a columns for CxxWrap.StdVector data type
+tree = RootIO.TTree(file, name, title; my_arr = CxxWrap.StdVector)
+# Write the CxxWrap.Std vector to the TTree
+v .= rand(Float32, 5)
+RootIO.Fill(tree, [v])
+RootIO.Write(tree)
+ROOT.Close(file)
+```
+
+## C-style arrays
+
+The syntax for creating a C-style array is ```array_name = (element_type, array_size)```, where:
+
+1. ```array_name``` is the name of column containing the array
+2. ```element_type``` is a data type or an instance of array element
+2. ```array_size``` is the symbol for variable having size of the array for fixed size array, or identifier of the branch that contains the length of the array in case of variable length array 
+
+### Fixed size C-style arrays
+
+```julia
+import RootIO, ROOT
+# Create and open the ROOT file
+file = ROOT.TFile!Open("example.root", "RECREATE")
+name = "example_tree"
+title = "Example TTree"
+# Store the size of array as variable
+my_arr_fixed_length = 3
+# Create the column for C-style array
+tree = RootIO.TTree(file, name, title; my_arr = (Int64, my_arr_fixed_length))
+# Write the C-style array to the TTree
+RootIO.Fill(tree, [[1,2,3]])
+RootIO.Write(tree)
+ROOT.Close(file)
+```
+
+### Variable size C-style arrays
+
+```julia
+import RootIO, ROOT
+# Create and open the the ROOT file
+file = ROOT.TFile!Open("example.root", "RECREATE")
+name = "example_tree"
+title = "Example TTree"
+# Create the column for array-size and the C-style array
+tree = RootIO.TTree(file, name, title; arr_size = Int64, my_arr = (Int64, :arr_size))
+# Write the C-style array along with its size to the TTree
+RootIO.Fill(tree, [3, [1,10,100]])
+RootIO.Fill(tree, [2, [2,20]])
+RootIO.Write(tree)
+ROOT.Close(file)
+```

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -1,0 +1,70 @@
+# Getting Started
+
+## Installation
+
+The `RootIO` module provides functionality for working with ROOT TTrees in Julia. It allows you to create, manage, and write TTrees to ROOT files, using a Julia-friendly API. This guide will walk you through the basic usage of `RootIO`.
+
+Before getting started, ensure you have the required dependencies installed. You'll need the following Julia packages:
+
+```julia
+using Pkg
+Pkg.add("ROOT")
+Pkg.add("Tables")
+Pkg.add("CxxWrap")
+```
+
+To install the latest version of RootIO.jl use the Julia's package manager by pressing the ```]``` in the REPL prompt:
+
+```julia
+julia> ]
+(v1.6) pkg> add RootIO
+```
+
+!!! compat "Use Julia 1.6 or newer"
+    RootIO.jl requires at least Julia v1.6 as it is dependent on ROOT.jl. Older versions of Julia are not supported.
+
+## Basic Methods in `RootIO`
+
+### `TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)`
+
+Creates a new RootIO TTree struct that is in abstraction over the ROOT TTree, with branches of a given type or branches having types inferred from the provided row instance.
+
+#### Example: 
+
+```julia
+mutable struct Event
+    x::Float32
+    y::Float32
+    z::Float32
+    v::CxxWrap.StdVector{Float32}
+end
+f = ROOT.TFile!Open("data.root", "RECREATE")
+# Create a RootIO ttree with columns x, y, z and v
+tree = RootIO.TTree(f, "mytree", "mytitle", Event)
+```
+
+### `Fill(tree::TTree, data)`
+
+Adds a row the the RootIO TTree with the given data.
+
+#### Example:
+```julia
+# Fille the TTree from previous example with an event e
+e.x, e.y, e.z = rand(3)
+resize!.([e.v], 5)
+e.v .= rand(Float32, 5)
+RootIO.Fill(tree, e)
+```
+
+
+### `Write(tree::TTree)`
+
+Writes a ROOT TTree to the associated ROOT file. Call this method after filling the entries to the TTree.
+
+#### Example:
+```julia
+RootIO.Write(tree)
+```
+
+!!! warning "Always close the ROOT file after your work is completed"
+    Close the ROOT file, 'f', with the help of ```ROOT.Close(f)``` after the analysis is completed

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -2,69 +2,70 @@
 
 ## Installation
 
-The `RootIO` module provides functionality for working with ROOT TTrees in Julia. It allows you to create, manage, and write TTrees to ROOT files, using a Julia-friendly API. This guide will walk you through the basic usage of `RootIO`.
+The `RootIO` module provides functionality for working with ROOT TTrees in Julia. It allows you to create, manage, and write TTrees to ROOT files using a Julia-friendly API. This guide will walk you through the basic usage of `RootIO`.
 
-Before getting started, ensure you have the required dependencies installed. You'll need the following Julia packages:
-
-```julia
-using Pkg
-Pkg.add("ROOT")
-Pkg.add("Tables")
-Pkg.add("CxxWrap")
-```
-
-To install the latest version of RootIO.jl use the Julia's package manager by pressing the ```]``` in the REPL prompt:
+To install the latest version of `RootIO.jl`, use Julia's package manager by pressing the `]` key in the REPL prompt. You should also install `ROOT.jl`.
 
 ```julia
 julia> ]
-(v1.6) pkg> add RootIO
+pkg> add RootIO
+pkg> add ROOT
 ```
 
 !!! compat "Use Julia 1.6 or newer"
-    RootIO.jl requires at least Julia v1.6 as it is dependent on ROOT.jl. Older versions of Julia are not supported.
+    RootIO.jl requires at least Julia v1.6.
 
 ## Basic Methods in `RootIO`
 
-### `TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)`
+### `TTree(file, name, title, rowtype)`
 
-Creates a new RootIO TTree struct that is in abstraction over the ROOT TTree, with branches of a given type or branches having types inferred from the provided row instance.
+Creates a new `RootIO` `TTree`, an abstraction over the `ROOT` `TTree`, to store rows of the specified type. `rowtype` must be a composite type. Each field of the composite type will be stored in a dedicated branch named after the field name.
 
 #### Example: 
 
 ```julia
+using RootIO, ROOT
 mutable struct Event
     x::Float32
     y::Float32
     z::Float32
-    v::CxxWrap.StdVector{Float32}
+    v::StdVector{Float32}
 end
+Event() = Event(0, 0, 0, StdVector(Float32[]))
 f = ROOT.TFile!Open("data.root", "RECREATE")
+
 # Create a RootIO ttree with columns x, y, z and v
 tree = RootIO.TTree(f, "mytree", "mytitle", Event)
+
+# Display the tree definition
+Print(tree)
 ```
 
-### `Fill(tree::TTree, data)`
+### `Fill(tree, row)`
 
-Adds a row the the RootIO TTree with the given data.
+Appends a row to the RootIO TTree.
 
 #### Example:
 ```julia
-# Fille the TTree from previous example with an event e
+# Fill the TTree from previous example with an event e
+e = Event()
 e.x, e.y, e.z = rand(3)
-resize!.([e.v], 5)
-e.v .= rand(Float32, 5)
+e.v = StdVector(rand(Float32, 5))
 RootIO.Fill(tree, e)
+
+#Display the tree contents
+Scan(tree)
 ```
 
+### `Write(tree)`
 
-### `Write(tree::TTree)`
-
-Writes a ROOT TTree to the associated ROOT file. Call this method after filling the entries to the TTree.
+Writes a ROOT TTree to the associated ROOT file. Call this method after filling the entries in the TTree to finalize the writing to disk.
 
 #### Example:
 ```julia
 RootIO.Write(tree)
 ```
 
-!!! warning "Always close the ROOT file after your work is completed"
-    Close the ROOT file, 'f', with the help of ```ROOT.Close(f)``` after the analysis is completed
+!!! warning "Closing the ROOT file"
+    To ensure the integrity of the ROOT file, `Close(f)` needs to be called after exiting Julia (more precisely, before the file instance is garbage collected). This is due to an issue in `ROOT.jl`, and this call will not be required anymore when the issue is fixed.
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,21 @@
-# RootIO.jl Documentation
+# RootIO.jl
 
-```@autodocs
-Modules = [RootIO]
+## Introduction
+
+Interface to ROOT file format with read/write support based on the C++ ROOT libraries.
+
+It uses a Julia interface to the official [ROOT](http://root.cern/) C++ libraries written using [WrapIt](https://github.com/grasph/wrapit) and [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl). It extends this interface to provide a user-friendly and Julia-like interface.
+
+This project is initiated in the context of the 2024 edition of the [Google Summer of Code](https://summerofcode.withgoogle.com/) program under the [CERN-HSF](https://github.com/JuliaHEP/RootIO.jl/blob/main/Introduction) organization.
+
+## Contents
+```@contents
+Pages = ["index.md", "gettingstarted.md", "typesandmethods.md", "examples.md"]
+Depth = 1
 ```
+
+## For contributors
+
+1. Add support for ROOT classes in [ROOT.jl](https://github.com/JuliaHEP/ROOT.jl)
+2. Add support for writing new classes and objects
+3. Translate [ROOT Tutorials](https://root.cern/doc/master/group__Tutorials.html) into equivalent Julia tutorials

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Interface to ROOT file format with read/write support based on the C++ ROOT libraries.
+The RootIO package provides an easy interface to read and write columnar data sets from and into [ROOT files](https://root.cern/manual/root_files) using the [`TTree`](https://root.cern/doc/master/classTTree.html) representation. A `TTree` is a columnar data representation stored on disk that supports an in-memory buffer for fast data access and automatic writing to disk. This package is based on [ROOT.jl](https://github.com/JuliaHEP/ROOT.jl), a package that provides Julia bindings to the C++ [ROOT](https://root.cern) API.
 
-It uses a Julia interface to the official [ROOT](http://root.cern/) C++ libraries written using [WrapIt](https://github.com/grasph/wrapit) and [CxxWrap](https://github.com/JuliaInterop/CxxWrap.jl). It extends this interface to provide a user-friendly and Julia-like interface.
+The original `TTree` API is heavily based on pointers; it does not translate well to Julia and is not easy to use. The `RootIO` module, to be used alongside the `ROOT` module, provides a higher-level and more user-friendly interface to `TTree`. `RootIO` defines its own `TTree` type to be used in place of `ROOT.TTree`.
 
-This project is initiated in the context of the 2024 edition of the [Google Summer of Code](https://summerofcode.withgoogle.com/) program under the [CERN-HSF](https://github.com/JuliaHEP/RootIO.jl/blob/main/Introduction) organization.
+_The development of this package was initiated in the context of the 2024 edition of the [Google Summer of Code](https://summerofcode.withgoogle.com/) program under the [CERN-HSF](https://github.com/JuliaHEP/RootIO.jl/blob/main/Introduction) organization._
 
 ## Contents
 ```@contents
@@ -16,30 +16,27 @@ Depth = 1
 
 ## Supported types
 
-| **Type**                 | **Description**                                   | **Supported** |
-|--------------------------|---------------------------------------------------|---------------|
-| String                   | A character string                                | ✅            |
-| Int8                     | An 8-bit signed integer                           | ✅            |
-| UInt8                    | An 8-bit unsigned integer                         | ✅            |
-| Int16                    | A 16-bit signed integer                           | ✅            |
-| UInt16                   | A 16-bit unsigned integer                         | ✅            |
-| Int32                    | A 32-bit signed integer                           | ✅            |
-| UInt32                   | A 32-bit unsigned integer                         | ✅            |
-| Float32                  | A 32-bit floating-point number                    | ✅            |
-| Half32b                  | 32 bits in memory, 16 bits on disk                | ❌            |
-| Float64                  | A 64-bit floating-point number                    | ✅            |
-| Double32c                | 64 bits in memory, 32 bits on disk                | ❌            |
-| Int64                    | A long signed integer, stored as 64-bit           | ✅            |
-| UInt64                   | A long unsigned integer, stored as 64-bit         | ✅            |
-| Bool                     | A boolean                                         | ✅            |
-| StdVector{T}             | A vector of elements of any of the above types    | ✅            |
-| C-array                  | A C-array of elements of any of the above types   | ✅            |
-| Simple structs           | A simple sturcts without any struct field         | ✅            |
-| Nested structs           | A sturcts with another struct as its field        | ❌            |
-| RNTuple                  | ROOT's experimental tuple data type               | ❌            |
+`TTree` represents data in two dimensions. Elements of this matrix can be of any type that can be defined in C++, including classes. In the botanical ROOT terminology, a column is called a branch and a row a tree entry.
 
-## For contributors
+`RootIO` includes support for most of the standard Julia primitive types, character strings (`String`), and vectors of elements of these types. Vectors of `Any` are not supported. The supported types are summarized in the table below.
 
-1. Add support for ROOT classes in [ROOT.jl](https://github.com/JuliaHEP/ROOT.jl)
-2. Add support for writing new classes and objects
-3. Translate [ROOT Tutorials](https://root.cern/doc/master/group__Tutorials.html) into equivalent Julia tutorials
+| **Type**       | **Description**                                                       | **Supported** |
+|----------------|-----------------------------------------------------------------------|---------------|
+| String         | A character string                                                    | ✅            |
+| Int8           | An 8-bit signed integer                                               | ✅            |
+| UInt8          | An 8-bit unsigned integer                                             | ✅            |
+| Int16          | A 16-bit signed integer                                               | ✅            |
+| UInt16         | A 16-bit unsigned integer                                             | ✅            |
+| Int32          | A 32-bit signed integer                                               | ✅            |
+| UInt32         | A 32-bit unsigned integer                                             | ✅            |
+| Float32        | A 32-bit floating-point number                                        | ✅            |
+| Float64        | A 64-bit floating-point number                                        | ✅            |
+| Int64          | A long signed integer, stored as 64-bit                               | ✅            |
+| UInt64         | A long unsigned integer, stored as 64-bit                             | ✅            |
+| Bool           | A boolean                                                             | ✅            |
+| StdVector{T}¹  | A vector of elements of any of the above types stored as std::vector  | ✅            |
+| Vector{T}      | A vector of elements of any of the above types stored as a C-array²   | ✅            |
+
+¹ `StdVector` is a subtype of `AbstractVector` provided by the CxxWrap package and reexported by `RootIO`. Use `StdVector([1, 2, 3])` to create a vector with elements 1, 2, and 3.
+
+² with a fixed size or a size specified in another column.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,6 +14,30 @@ Pages = ["index.md", "gettingstarted.md", "typesandmethods.md", "examples.md"]
 Depth = 1
 ```
 
+## Supported types
+
+| **Type**                 | **Description**                                   | **Supported** |
+|--------------------------|---------------------------------------------------|---------------|
+| String                   | A character string                                | ✅            |
+| Int8                     | An 8-bit signed integer                           | ✅            |
+| UInt8                    | An 8-bit unsigned integer                         | ✅            |
+| Int16                    | A 16-bit signed integer                           | ✅            |
+| UInt16                   | A 16-bit unsigned integer                         | ✅            |
+| Int32                    | A 32-bit signed integer                           | ✅            |
+| UInt32                   | A 32-bit unsigned integer                         | ✅            |
+| Float32                  | A 32-bit floating-point number                    | ✅            |
+| Half32b                  | 32 bits in memory, 16 bits on disk                | ❌            |
+| Float64                  | A 64-bit floating-point number                    | ✅            |
+| Double32c                | 64 bits in memory, 32 bits on disk                | ❌            |
+| Int64                    | A long signed integer, stored as 64-bit           | ✅            |
+| UInt64                   | A long unsigned integer, stored as 64-bit         | ✅            |
+| Bool                     | A boolean                                         | ✅            |
+| StdVector{T}             | A vector of elements of any of the above types    | ✅            |
+| C-array                  | A C-array of elements of any of the above types   | ✅            |
+| Simple structs           | A simple sturcts without any struct field         | ✅            |
+| Nested structs           | A sturcts with another struct as its field        | ❌            |
+| RNTuple                  | ROOT's experimental tuple data type               | ❌            |
+
 ## For contributors
 
 1. Add support for ROOT classes in [ROOT.jl](https://github.com/JuliaHEP/ROOT.jl)

--- a/docs/src/typesandmethods.md
+++ b/docs/src/typesandmethods.md
@@ -1,0 +1,6 @@
+# Types & Methods
+
+```@autodocs
+Modules = [RootIO]
+Order   = [:type, :function]
+```

--- a/src/RootIO.jl
+++ b/src/RootIO.jl
@@ -28,12 +28,10 @@ function Write(tree::TTree)
     ROOT.Write(tree._ROOT_ttree)
 end
 
-"""
-    _getTypeCharacter(julia_type::DataType)
-Returns the TTree type code for the input Julia data type
-# Arguments
-- `julia_type::DataType`: The Julia type for which TTree type code is required.
-"""
+#     _getTypeCharacter(julia_type::DataType)
+# Returns the TTree type code for the input Julia data type
+# # Arguments
+# - `julia_type::DataType`: The Julia type for which TTree type code is required.
 function _getTypeCharacter(julia_type::DataType)
     if julia_type == String
         return "C"
@@ -66,21 +64,19 @@ function _getTypeCharacter(julia_type::DataType)
     end
 end
 
-"""
-    _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, branch_types, branch_names)
+#     _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, branch_types, branch_names)
 
-Creates a ROOT TTree with specified branches.
+# Creates a ROOT TTree with specified branches.
 
-# Arguments
-- `file`: A pointer to a ROOT file where the TTree will be stored.
-- `name`: The name of the TTree.
-- `title`: The title of the TTree.
-- `branch_types`: A collection of types for the branches.
-- `branch_names`: A collection of names for the branches.
+# # Arguments
+# - `file`: A pointer to a ROOT file where the TTree will be stored.
+# - `name`: The name of the TTree.
+# - `title`: The title of the TTree.
+# - `branch_types`: A collection of types for the branches.
+# - `branch_names`: A collection of names for the branches.
 
-# Returns
-- A RootIO `TTree` object containing the ROOT TTree and its branches.
-"""
+# # Returns
+# - A RootIO `TTree` object containing the ROOT TTree and its branches.
 function _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, branch_types, branch_names)
     tree = ROOT.TTree(name, title)
     current_branches = []
@@ -113,7 +109,7 @@ function _makeTTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, 
 end
 
 """
-    TTree(file, name, title, data)
+    TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String, data)
 
 Creates a new ROOT TTree with branches of given type or branches having types infered from the given data (data is not written to the tree).
 
@@ -174,6 +170,7 @@ name = "example_tree"
 title = "Example TTree"
 data = (col_float=rand(Float64, 3), col_int=rand(Int32, 3))
 tree = RootIO.TTree(file, name, title; data...)
+```
 """
 function TTree(file::CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}, name::String, title::String; kwargs...)
     _branch_types_array = []
@@ -203,11 +200,7 @@ Fills a ROOT TTree with the provided data.
 # Example
 ```julia
 # Assuming `tree` is an existing TTree and `data` is a table or row
-file = ROOT.TFile!Open("example.root", "RECREATE")
-name = "example_tree"
-title = "Example TTree"
-tree = RootIO.TTree(file, name, title, [Float64])
-RootIO.Fill(tree, 1.0)
+Fill(tree, data)
 ```
 """
 function Fill(tree::TTree, data)


### PR DESCRIPTION
This pull request adds the documentation generated with `documenter.jl`, pull request templates and deployment workflow for documentation.

A preview of the documentation can be found at [RootIO.jl site from my repo](https://yashnator.github.io/RootIO.jl/dev/).

To-do:
- [x] Add workflow
- [x] Create pages for introduction, methods & types, getting started and example
- [x] Create examples for I/O of primitive types
- [x] Create examples for I/O of vectors and C-array
- [x] Add pull request template

Checklist before requesting a review:
- [x] Tested on GitHub pages